### PR TITLE
Catch error when trying to retrieve client IP for logging purposes

### DIFF
--- a/src/Aptoma/Log/RequestProcessor.php
+++ b/src/Aptoma/Log/RequestProcessor.php
@@ -32,7 +32,11 @@ class RequestProcessor
 
     public function __invoke(array $record)
     {
-        $record['extra']['clientIp'] = $this->getClientIp($this->app['request_stack']);
+        try {
+            $record['extra']['clientIp'] = $this->getClientIp($this->app['request_stack']);
+        } catch (\Exception $e) {
+            $record['extra']['clientIp'] = '';
+        }
         if ($this->app->offsetExists('security')) {
             $record['extra']['user'] = $this->getUsername($this->app['security']);
         }


### PR DESCRIPTION
Solves #5 until we have the opportunity to upgrade to the newest version of symfony/http-foundation 