### PR TITLE
add ConsoleLoggerServiceProvider fork note

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The console logger overrides the default `monolog.handler` in order to allow set
 a custom log file. If defined, it will use `monolog.console_logfile`, and if not, it
 will fall back to `monolog.logfile`.
 
+This Provider is also available as standalone package: https://github.com/glensc/ConsoleLoggerServiceProvider
+
 ### Aptoma\Silex\Application
 
 This is a base application you can extend. It will add a json formatter for errors,


### PR DESCRIPTION
i needed solution to use logger to print to terminal, and came up with service from this project.

as youyr version is old and i needed pimple 3 support, created kind of fork: https://github.com/glensc/ConsoleLoggerServiceProvider

kind of, because manually picked commits to re-create history of the single file only. maybe wasn't needed, but i like to give authors credit ;)